### PR TITLE
Fix flaky test testInstanceTemplatePrototypeInstanceByVolume

### DIFF
--- a/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceByVolumeTest.java
+++ b/modules/vpc/src/test/java/com/ibm/cloud/is/vpc/v1/model/InstanceTemplatePrototypeInstanceByVolumeTest.java
@@ -13,6 +13,8 @@
 
 package com.ibm.cloud.is.vpc.v1.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.ibm.cloud.is.vpc.v1.model.EncryptionKeyIdentityByCRN;
 import com.ibm.cloud.is.vpc.v1.model.InstancePlacementTargetPrototypeDedicatedHostIdentityDedicatedHostIdentityById;
 import com.ibm.cloud.is.vpc.v1.model.InstanceProfileIdentityByName;
@@ -195,7 +197,7 @@ public class InstanceTemplatePrototypeInstanceByVolumeTest {
     assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.totalVolumeBandwidth(), Long.valueOf("500"));
     assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.userData(), "testString");
     assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.vpc().toString(), vpcIdentityModel.toString());
-    assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.bootVolumeAttachment().toString(), volumeAttachmentPrototypeInstanceByVolumeContextModel.toString());
+    assertEquals(JsonParser.parseString(instanceTemplatePrototypeInstanceByVolumeModelNew.bootVolumeAttachment().toString()), JsonParser.parseString(volumeAttachmentPrototypeInstanceByVolumeContextModel.toString()));
     assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.primaryNetworkInterface().toString(), networkInterfacePrototypeModel.toString());
     assertEquals(instanceTemplatePrototypeInstanceByVolumeModelNew.zone().toString(), zoneIdentityModel.toString());
   }


### PR DESCRIPTION
## The Problem

The test case `com.ibm.cloud.is.vpc.v1.model.InstanceTemplatePrototypeInstanceByVolumeTest.testInstanceTemplatePrototypeInstanceByVolume` is flaky as was discovered through the plug-in [NonDex](https://github.com/TestingResearchIllinois/NonDex). Here is the full step to reproduce the issue:

```
git clone https://github.com/IBM/vpc-java-sdk && cd vpc-java-sdk
export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
mvn clean install -pl modules/vpc -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl modules/vpc -Dtest=InstanceTemplatePrototypeInstanceByVolumeTest#testInstanceTemplatePrototypeInstanceByVolume
```

The build will fail.

The current implementation compares two serializations with each other. However, it would be safer to directly compare the objects themselves to avoid any issues where serialization strings are different but representing the same object. NonDex shuffles the ordering of fields, so the test case will fail without having any real issues.

## The Fix

It's a very simple fix, instead of comparing serializations, `JsonParser` from GSON is used to compare their deserialized forms to make sure that the test case will not fail because a field in the serialization string is in a different ordering from another that is constructed from the same object.

There are a few other test cases in the project that has similar issues, which can also be discovered through running NonDex for the whole project. Please do give some feedbacks on whether you think this way of fixing it is feasible. Thanks!